### PR TITLE
Fix unfollowed symlinks

### DIFF
--- a/mp2v_tree.js
+++ b/mp2v_tree.js
@@ -121,10 +121,6 @@ function streamForWrapped(files, f) {
   }
 
   // stream for a file
-  if (f.children.length > 0) { // sanity check
-    throw new Error("non-directory has children. lib error")
-  }
-
   return f.file.contents
 }
 


### PR DESCRIPTION
This module currently breaks when adding symlinks that are not followed (when the consumer passes `followSymlinks: false` to `vinyl-fs`). This would create a case where a file would have children, but `file.isDirectory()` would return false, causing an error when processed by `vinyl-multipart-stream`.

This PR removes the sanity check that was breaking this case.
